### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,91 @@
+import Buffer from 'bare-buffer'
+import URL from 'bare-url'
+
+interface MemoryFileOptions {
+  executable?: boolean
+  mode?: number
+}
+
+interface MemoryFile {
+  mode(): number
+  read(): Buffer
+  size(): number
+}
+
+declare class MemoryFile {
+  constructor(data: string | Buffer, opts?: MemoryFileOptions)
+}
+
+interface BundleOptions {
+  File?: typeof MemoryFile
+}
+
+type RecursiveStringObject = { [key: string]: string | RecursiveStringObject }
+
+interface BundleWriteOptions {
+  addon?: boolean
+  alias?: string
+  asset?: boolean
+  executable?: boolean
+  imports?: RecursiveStringObject
+  main?: boolean
+  mode?: number
+}
+
+interface BundleMountOptions {
+  conditions?: { [condition: string]: string | URL }
+}
+
+interface BundleToBufferOptions {
+  indent?: number
+}
+
+interface Bundle extends Iterable<[key: string, read: Buffer, mode: number]> {
+  readonly files: Record<string, MemoryFile>
+  readonly version: number
+
+  addons: string[]
+  assets: string[]
+  id: string | null
+  imports: RecursiveStringObject
+  main: string | null
+  resolutions: RecursiveStringObject
+
+  keys(): string[]
+
+  exists(key: string): boolean
+
+  mode(key: string): number
+
+  read(key: string): Buffer
+
+  write(key: string, data: string, opts?: BundleWriteOptions): this
+
+  mount(root: string | URL, opts?: BundleMountOptions): Bundle
+
+  unmount(root: string | URL, opts?: BundleMountOptions): Bundle
+
+  toBuffer(opts?: BundleToBufferOptions): Buffer
+}
+
+declare class Bundle {
+  static readonly version: number
+
+  constructor(opts?: BundleOptions)
+}
+
+declare namespace Bundle {
+  export {
+    type MemoryFile,
+    type MemoryFileOptions,
+    type BundleOptions,
+    type BundleWriteOptions,
+    type BundleMountOptions,
+    type BundleToBufferOptions
+  }
+
+  export function isBundle(value: unknown): value is Bundle
+  export function from(value: string | Buffer | Bundle): Bundle
+}
+
+export = Bundle

--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
   "name": "bare-bundle",
   "version": "1.8.3",
   "description": "Application bundle format for JavaScript",
-  "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./package": "./package.json"
+  },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "prettier . --check && bare test.js"
@@ -20,8 +27,22 @@
   },
   "homepage": "https://github.com/holepunchto/bare-bundle#readme",
   "devDependencies": {
+    "bare-buffer": "^3.0.2",
+    "bare-url": "^2.1.3",
     "brittle": "^3.1.1",
     "prettier": "^3.4.2",
     "prettier-config-standard": "^7.0.0"
+  },
+  "peerDependencies": {
+    "bare-buffer": "*",
+    "bare-url": "*"
+  },
+  "peerDependenciesMeta": {
+    "bare-buffer": {
+      "optional": true
+    },
+    "bare-url": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Should we type the `bare.inspect` parts? I ignored them because it doesn't seem to be part from the public API to me.